### PR TITLE
Migrated from deprecated setup.py to pyproject.toml build system 

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,30 +9,29 @@
 
 ## Clone
 
-```bash
-cd ~
-git clone https://github.com/miwashi-edu/pentest-toolbox.git # Change to the repository URL you copied in step 4
-cd pentest-toolbox # Adjust to the name you chose in step 3.
+```console
+user@linux:~$ cd ~
+user@linux:~$ git clone https://github.com/miwashi-edu/pentest-toolbox.git # Change to the repository URL you copied in step 4
+user@linux:~$ cd pentest-toolbox # Adjust to the name you chose in step 3.
 
-#python -m venv venv
-#source ./venv/bin/activate # Activate venv
+user@linux:pentest-toolbox$ python -m venv venv
+user@linux:pentest-toolbox$ source ./venv/bin/activate # Activate venv
 
 # Install the project and its dependencies
-#python3 setup.py install
+(venv) user@linux:pentest-toolbox$ python -m build .
+(venv) user@linux:pentest-toolbox$ sudo python -m installer dist/*.whl
 
 # Additional setup steps (if any, based on the project's README)
 
 # Your commands to run the project (based on the project's documentation)
 
-#deactivate # Quit venv when you are ready
+(venv) user@linux:pentest-toolbox$ deactivate # Quit venv when you are ready
 ```
 
 ## Create project scaffold
 
 ```bash
-cd ws
-cd pentest-toolbox
-touch requirements.txt
+cd ~/pentest-toolbox
 echo "# pentest-toolbox" > README.md
 mkdir tests
 touch tests/__init__.py
@@ -52,24 +51,38 @@ git add .
 git commit -m "Initial commit"
 ```
 
-## Create setup.py
+## Create pyproject.toml
 
 ```bash
-cd ws
-cd pentest-toolbox
-cat > setup.py << EOF
-from setuptools import setup, find_packages
+cd ~/pentest-toolbox
+cat > pyproject.toml << EOF
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
 
-setup(
-    name='pentest-toolbox',
-    version='0.1.0',
-    packages=find_packages(),
-    entry_points={
-        'console_scripts': [
-            'hello=hello_world.main:main',
-        ],
-    },
-)
+[project]
+name = "pentest_toolbox"
+version = "0.1.0"
+description = "A test project"
+authors = [
+    {name = "Anton Hvornum", email = "anton@hvornum.se"},
+]
+license = {text = "AGPL-1.0-or-later"}
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+]
+
+[project.scripts]
+hello = "hello_world.main:main"
+
+[options]
+package_dir="hello_world"
+include_package_data = true
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["hello_world*"]
 EOF
 ```
 
@@ -141,7 +154,7 @@ EOF
 ### Result
 
 ```
-~/ws/pentest-toolbox/
+~/pentest-toolbox/
 │
 ├── hello_world/
 │   ├── __init__.py
@@ -158,25 +171,13 @@ EOF
 │
 ├── .gitignore
 ├── README.md
-├── requirements.txt
-└── setup.py
-```
-
-## Create pip configuration
-
-> It tells pip (acronym for "Pip Installs Packages" or "Pip Installs Python") where our commands will be installed in the system.
-
-```bash
-mkdir -p ~/.pip
-touch ~/.pip/pip.conf
-cat > ~/.pip/pip.conf << 'EOF'
-[install]
-install-option=--prefix=/usr/local
-EOF
+└── pyproject.toml
 ```
 
 ## Install the hello command
 
-```bash
-pip install . --prefix=/usr/local
+```console
+user@linux:~$ cd pentest-toolbox
+user@linux:pentest-toolbox$ python -m build .
+user@linux:pentest-toolbox$ sudo python -m installer --prefix /usr/local dist/*.whl
 ```


### PR DESCRIPTION
# Packaging

setup.py has long since been a deprecated practice unless you specifically need to do setuptools related modifications pre-packaging. Despite `pip` still supporting `setup.py` it's not recommended.

Instead, supplying a declarative text file containing your projects details and needs is the preferred method, which is what [pyproject.toml](https://pip.pypa.io/en/stable/reference/build-system/pyproject-toml/) is. Aside from being a industry standard which should be taught, it's also an easier concept to grasp since it's a simple text file declaring information.

This also supports more build backends, such as [poetry](https://python-poetry.org/) which tends to be the industry standard for any Python programming projects, and supporting this from the first introduction should make it less confusing when introducing what build backends are or when programmers go out in real life scenarios.

This is also a quite old concept, as it was introduced back in 2015 and very few big projects still use the legacy method of packaging libraries.

# Linux terminal hygiene

As this is an introduction, this sets future habits. I therefore strongly advise against teaching the use of `venv` as `root` unless strictly necessary, as it could very well lead to serious consequences if the user isn't aware of potential changes to the venv in real world scenarios.

# code syntax

It's also cleaner to use the `console` syntax highlighting for the code blocks, as `#` is identified as a comment, not a root command. Thus mixing root commands and comments some times on the same line becomes a bit unreadable when using `bash` as the highlight syntax in the README.

The improved syntax and changes should clear that out.

Old highlighting:
 
![screenshot](https://github.com/miwashi-edu/edu-python-intro/assets/861439/aac1d2e4-b22d-497d-8fa7-c12be38ebadd)

New highlighting:

![screenshot2](https://github.com/miwashi-edu/edu-python-intro/assets/861439/1e4892ef-bed0-4356-a2f1-8340abb6b0e7)

Comments are now comments, and root are no longer comments by instructing users to use `sudo` instead.

# Installing

Avoid using `pip` if possible, since the default backend is `build` and `installer`. `pip` is a helper tool, but makes it hard to separate build and installation. It also forces users into a specific build backend and frontend.

Conceptually it's also less steps, since it doesn't require creating a pip configuration for the specific needs. So complexity is not increased.

Sources:
- https://packaging.python.org/en/latest/discussions/setup-py-deprecated/
- https://peps.python.org/pep-0517/